### PR TITLE
Troubleshoot and research solution

### DIFF
--- a/nushell/scripts/core/start_yazelix.nu
+++ b/nushell/scripts/core/start_yazelix.nu
@@ -27,7 +27,30 @@ export def main [] {
     # The YAZELIX_DEFAULT_SHELL variable will be set by the shellHook of the flake
     # and used by the inner zellij command.
     # We use bash -c '...' to ensure $YAZELIX_DEFAULT_SHELL is expanded after nix develop sets it.
-    let cmd = $"zellij --config-dir \"($yazelix_dir)/configs/zellij\" options --default-cwd \"($home)\" --default-layout yazelix --default-shell \"$YAZELIX_DEFAULT_SHELL\""
+    # Build the appropriate zellij command based on persistent session setting
+    let cmd = if ($config.persistent_sessions == "true") {
+        # Use zellij attach with create flag for persistent sessions
+        [
+            "zellij"
+            "--config-dir" $"($yazelix_dir)/configs/zellij"
+            "attach"
+            "-c" $config.session_name
+            "options"
+            "--default-cwd" $home
+            "--default-layout" "yazelix"
+            "--default-shell" "$YAZELIX_DEFAULT_SHELL"
+        ] | str join " "
+    } else {
+        # Use zellij options for new sessions (original behavior)
+        [
+            "zellij"
+            "--config-dir" $"($yazelix_dir)/configs/zellij"
+            "options"
+            "--default-cwd" $home
+            "--default-layout" "yazelix"
+            "--default-shell" "$YAZELIX_DEFAULT_SHELL"
+        ] | str join " "
+    }
     
     with-env {HOME: $home} {
         ^nix develop --impure --command bash -c $cmd


### PR DESCRIPTION
Implement Zellij persistent sessions and refactor `zellij` command construction for readability and maintainability.

This PR introduces the conditional logic to launch Zellij with persistent session support using `zellij attach -c`. The `zellij` command construction has been refactored to use Nushell's array and `str join` for improved readability and maintainability, resolving previous issues with multi-line string syntax. It also ensures the necessary `options` flag is included for persistent sessions.

---

[Open in Web](https://cursor.com/agents?id=bc-11282f17-b1e0-4b08-9e81-f2e389f45a91) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-11282f17-b1e0-4b08-9e81-f2e389f45a91) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)